### PR TITLE
Only display child posts option for posts shortcodes

### DIFF
--- a/admin/shortcodes/shortcodes/my_mini_posts_grid.js
+++ b/admin/shortcodes/shortcodes/my_mini_posts_grid.js
@@ -72,6 +72,15 @@ frameworkShortcodeAtts={
 				help:"Alignment of grid - left, right, or center."
 			},
 			{
+				label:"Display only child posts",
+				id:"only_child_posts",
+				controlType:"select-control",
+				selectValues:['yes', 'no'],
+				defaultValue: 'no',
+				defaultText: 'no',
+				help:"Display only child posts of the current post."
+			},
+			{
 				label:"Custom class",
 				id:"custom_class",
 				help:"Use this field if you want to use a custom class."

--- a/admin/shortcodes/shortcodes/my_mini_posts_list.js
+++ b/admin/shortcodes/shortcodes/my_mini_posts_list.js
@@ -62,6 +62,15 @@ frameworkShortcodeAtts={
 				help:"How many words are displayed in the excerpt?"
 			},
 			{
+				label:"Display only child posts",
+				id:"only_child_posts",
+				controlType:"select-control",
+				selectValues:['yes', 'no'],
+				defaultValue: 'no',
+				defaultText: 'no',
+				help:"Display only child posts of the current post."
+			},
+			{
 				label:"Custom class",
 				id:"custom_class",
 				help:"Use this field if you want to use a custom class."

--- a/admin/shortcodes/shortcodes/my_posts_grid.js
+++ b/admin/shortcodes/shortcodes/my_posts_grid.js
@@ -90,6 +90,15 @@ frameworkShortcodeAtts={
 				help:"Enter tags for posts filtering. Leave blank to pull all tags"
 			},
 			{
+				label:"Display only child posts",
+				id:"only_child_posts",
+				controlType:"select-control",
+				selectValues:['yes', 'no'],
+				defaultValue: 'no',
+				defaultText: 'no',
+				help:"Display only child posts of the current post."
+			},
+			{
 				label:"Custom class",
 				id:"custom_class",
 				help:"Use this field if you want to use a custom class for posts."

--- a/admin/shortcodes/shortcodes/my_posts_list.js
+++ b/admin/shortcodes/shortcodes/my_posts_list.js
@@ -75,15 +75,15 @@ frameworkShortcodeAtts={
 				id:"tag",
 				help:"Enter tags for posts filtering. Leave blank to pull all tags"
 			},
-      {
-        label:"Display only child posts",
-        id:"only_child_posts",
-        controlType:"select-control",
-        selectValues:['yes', 'no'],
-        defaultValue: 'no',
-        defaultText: 'no',
-        help:"Display only child posts of the current post."
-      },
+			{
+			label:"Display only child posts",
+			id:"only_child_posts",
+			controlType:"select-control",
+			selectValues:['yes', 'no'],
+			defaultValue: 'no',
+			defaultText: 'no',
+			help:"Display only child posts of the current post."
+			},
 			{
 				label:"Tags",
 				id:"tags",

--- a/admin/shortcodes/shortcodes/my_posts_list.js
+++ b/admin/shortcodes/shortcodes/my_posts_list.js
@@ -75,6 +75,15 @@ frameworkShortcodeAtts={
 				id:"tag",
 				help:"Enter tags for posts filtering. Leave blank to pull all tags"
 			},
+      {
+        label:"Display only child posts",
+        id:"only_child_posts",
+        controlType:"select-control",
+        selectValues:['yes', 'no'],
+        defaultValue: 'no',
+        defaultText: 'no',
+        help:"Display only child posts of the current post."
+      },
 			{
 				label:"Tags",
 				id:"tags",

--- a/includes/shortcodes/mini-posts-grid.php
+++ b/includes/shortcodes/mini-posts-grid.php
@@ -6,18 +6,19 @@
 if (!function_exists('mini_posts_grid_shortcode')) {
 	function mini_posts_grid_shortcode( $atts, $content = null, $shortcodename = '' ) {
 		extract(shortcode_atts(array(
-			'type'         => 'post',
+			'type'             => 'post',
 			'category'         => '',
 			'custom_category'  => '',
-			'numb'         => '8',
-			'thumbs'       => '',
-			'thumb_width'  => '',
-			'thumb_height' => '',
-			'lightbox'	   => 'yes',
-			'order_by'     => 'date',
-			'order'        => 'DESC',
-			'align'        => '',
-			'custom_class' => ''
+			'numb'             => '8',
+			'thumbs'           => '',
+			'thumb_width'      => '',
+			'thumb_height'     => '',
+			'lightbox'	       => 'yes',
+			'order_by'         => 'date',
+			'order'            => 'DESC',
+			'align'            => '',
+			'custom_class'     => '',
+			'only_child_posts' => ''
 		), $atts));
 
 		$template_url = get_stylesheet_directory_uri();
@@ -87,6 +88,10 @@ if (!function_exists('mini_posts_grid_shortcode')) {
 				'order'            => $order,
 				'suppress_filters' => $suppress_filters
 			);
+
+			if ($only_child_posts == 'yes') {
+				$args['post_parent'] = $post->ID;
+			}
 
 			$posts = get_posts($args);
 			$i = 0;

--- a/includes/shortcodes/mini-posts-list.php
+++ b/includes/shortcodes/mini-posts-list.php
@@ -7,16 +7,17 @@ if (!function_exists('mini_posts_list_shortcode')) {
 
 	function mini_posts_list_shortcode( $atts, $content = null, $shortcodename = '' ) {
 		extract(shortcode_atts(array(
-			'type'          => 'post',
-			'numb'          => '3',
-			'thumbs'        => '',
-			'thumb_width'   => '',
-			'thumb_height'  => '',
-			'meta'          => '',
-			'order_by'      => '',
-			'order'         => '',
-			'excerpt_count' => '0',
-			'custom_class'  => ''
+			'type'             => 'post',
+			'numb'             => '3',
+			'thumbs'           => '',
+			'thumb_width'      => '',
+			'thumb_height'     => '',
+			'meta'             => '',
+			'order_by'         => '',
+			'order'            => '',
+			'excerpt_count'    => '0',
+			'custom_class'     => '',
+			'only_child_posts' => ''
 		), $atts));
 
 		$template_url = get_template_directory_uri();
@@ -84,6 +85,10 @@ if (!function_exists('mini_posts_list_shortcode')) {
 				'order'            => $order,
 				'suppress_filters' => $suppress_filters
 			);
+
+			if ($only_child_posts == 'yes') {
+				$args['post_parent'] = $post->ID;
+			}
 
 			$posts = get_posts($args);
 			$i = 0;

--- a/includes/shortcodes/posts-grid.php
+++ b/includes/shortcodes/posts-grid.php
@@ -7,22 +7,23 @@ if (!function_exists('posts_grid_shortcode')) {
 
 	function posts_grid_shortcode( $atts, $content = null, $shortcodename = '' ) {
 		extract(shortcode_atts(array(
-			'type'            => 'post',
-			'category'        => '',
-			'custom_category' => '',
-			'tag'             => '',
-			'columns'         => '3',
-			'rows'            => '3',
-			'order_by'        => 'date',
-			'order'           => 'DESC',
-			'thumb_width'     => '370',
-			'thumb_height'    => '250',
-			'lightbox'  	  => 'yes',
-			'meta'            => '',
-			'excerpt_count'   => '15',
-			'link'            => 'yes',
-			'link_text'       => __('Read more', CHERRY_PLUGIN_DOMAIN),
-			'custom_class'    => ''
+			'type'             => 'post',
+			'category'         => '',
+			'custom_category'  => '',
+			'tag'              => '',
+			'columns'          => '3',
+			'rows'             => '3',
+			'order_by'         => 'date',
+			'order'            => 'DESC',
+			'thumb_width'      => '370',
+			'thumb_height'     => '250',
+			'lightbox'  	   => 'yes',
+			'meta'             => '',
+			'excerpt_count'    => '15',
+			'link'             => 'yes',
+			'link_text'        => __('Read more', CHERRY_PLUGIN_DOMAIN),
+			'custom_class'     => '',
+			'only_child_posts' => ''
 		), $atts));
 
 		$spans = $columns;
@@ -101,6 +102,10 @@ if (!function_exists('posts_grid_shortcode')) {
 				'order'             => $order,
 				'suppress_filters'  => $suppress_filters
 			);
+
+			if ($only_child_posts == 'yes') {
+				$args['post_parent'] = $post->ID;
+			}
 
 			$posts = get_posts( $args );
 

--- a/includes/shortcodes/posts-list.php
+++ b/includes/shortcodes/posts-list.php
@@ -7,19 +7,20 @@ if (!function_exists('posts_list_shortcode')) {
 
 	function posts_list_shortcode( $atts, $content = null, $shortcodename = '' ) {
 		extract(shortcode_atts(array(
-			'type'         => 'post',
-			'thumbs'       => '',
-			'thumb_width'  => '',
-			'thumb_height' => '',
-			'post_content' => '',
-			'numb'         => '5',
-			'order_by'     => '',
-			'order'        => '',
-			'link'         => '',
-			'link_text'    => __('Read more', CHERRY_PLUGIN_DOMAIN),
-			'tag'          => '',
-			'tags'         => '',
-			'custom_class' => ''
+			'type'             => 'post',
+			'thumbs'           => '',
+			'thumb_width'      => '',
+			'thumb_height'     => '',
+			'post_content'     => '',
+			'numb'             => '5',
+			'order_by'         => '',
+			'order'            => '',
+			'link'             => '',
+			'link_text'        => __('Read more', CHERRY_PLUGIN_DOMAIN),
+			'tag'              => '',
+			'tags'             => '',
+			'custom_class'     => '',
+			'only_child_posts' => '',
 		), $atts));
 
 		// check what order by method user selected
@@ -63,6 +64,10 @@ if (!function_exists('posts_list_shortcode')) {
 			'order'            => $order,
 			'suppress_filters' => $suppress_filters
 		);
+
+		if ($only_child_posts == 'yes') {
+			$args['post_parent'] = $post->ID;
+		}
 
 		$posts = get_posts($args);
 		$i = 0;


### PR DESCRIPTION
This pull request adds a new option `only_child_posts` to the shortcodes `posts_list`, `posts_grid`, `mini_posts_list` and `mini_posts_grid` which, when enabled, will only display the child posts belonging to the post which contains the short code.

e.g.

	[posts_list type="page" thumbs="small" post_content="excerpt" link="yes" only_child_posts="yes"]
